### PR TITLE
Removed unnecessary check in Vector.subtract()

### DIFF
--- a/lib/src/Tracer/javascript/Tracer.js
+++ b/lib/src/Tracer/javascript/Tracer.js
@@ -171,8 +171,7 @@ Vector.prototype = {
     return new Vector(v.x + this.x, v.y + this.y, v.z + this.z);
   },
 
-  subtract: function (v) {
-    if (!v || !this) throw 'Vectors must be defined [' + this + ',' + v + ']';
+  subtract: function (v) {    
     return new Vector(this.x - v.x, this.y - v.y, this.z - v.z);
   },
 


### PR DESCRIPTION
this check is not necessary, I think it's a leftover prior to manual optimization. E.g. the `add` operator does not have it.

Eliminating this check makes raytracer ~25% faster, pushing JavaScript close to `dart2js` performances in the benchmark.
