### PR TITLE
Ray and IntersectionInfo turned into plain javascript objects for speed increase

### DIFF
--- a/lib/src/Tracer/javascript/Tracer.js
+++ b/lib/src/Tracer/javascript/Tracer.js
@@ -188,17 +188,17 @@ Vector.prototype = {
   }
 }
 
-var Ray = function (pos, dir) {
-  this.position = pos;
-  this.direction = dir;
-};
+function Ray(pos, dir) {
+  return { position: pos, direction: dir};
+}
 
-
+/*
 Ray.prototype = {
   toString: function () {
     return 'Ray [' + this.position + ',' + this.direction + ']';
   }
 }
+*/
 
 var Scene = function () {
   this.camera = new Camera(
@@ -301,7 +301,7 @@ var Sphere = function (pos, radius, material) {
 
 Sphere.prototype = {
   intersect: function (ray) {
-    var info = new IntersectionInfo();
+    var info = IntersectionInfo();
     info.shape = this;
 
     var dst = ray.position.subtract(this.position);
@@ -336,7 +336,7 @@ var Plane = function (pos, d, material) {
 
 Plane.prototype = {
   intersect: function (ray) {
-    var info = new IntersectionInfo();
+    var info = IntersectionInfo();
 
     var Vd = this.position.dot(ray.direction);
     if (Vd == 0) return info; // no intersection
@@ -368,22 +368,26 @@ Plane.prototype = {
   }
 }
 
-var IntersectionInfo = function () {
-  this.color = new Color(0, 0, 0);
-  this.isHit = false;
-  this.hitCount = 0;
-  this.shape = null;
-  this.position = null;
-  this.normal = null;
-  this.color = null;
-  this.distance = null;
-};
+function IntersectionInfo() {
+  return {
+	  color: new Color(0, 0, 0),
+	  isHit: false,
+	  hitCount: 0,
+	  shape: null,
+	  position: null,
+	  normal: null,
+	  color: null,
+	  distance: null
+  };
+}
 
+/*
 IntersectionInfo.prototype = {
   toString: function () {
     return 'Intersection [' + this.position + ']';
   }
 }
+*/
 
 var Camera = function (pos, lookAt, up) {
   this.position = pos;
@@ -399,7 +403,7 @@ Camera.prototype = {
       this.equator.multiplyScalar(vx).subtract(this.up.multiplyScalar(vy)));
     pos.y = pos.y * -1;
     var dir = pos.subtract(this.position);
-    var ray = new Ray(pos, dir.normalize());
+    var ray = Ray(pos, dir.normalize());
     return ray;
   },
 
@@ -485,7 +489,7 @@ Engine.prototype = {
 
   testIntersection: function (ray, scene, exclude) {
     var hits = 0;
-    var best = new IntersectionInfo();
+    var best = IntersectionInfo();
     best.distance = 2000;
 
     for (var i = 0; i < scene.shapes.length; i++) {
@@ -505,7 +509,7 @@ Engine.prototype = {
   getReflectionRay: function (P, N, V) {
     var c1 = -N.dot(V);
     var R1 = N.multiplyScalar(2 * c1).add(V);
-    return new Ray(P, R1);
+    return Ray(P, R1);
   },
 
   rayTrace: function (info, ray, scene, depth) {
@@ -552,9 +556,9 @@ Engine.prototype = {
       }
 
       /* Render shadows and highlights */
-      var shadowInfo = new IntersectionInfo();
+      var shadowInfo = IntersectionInfo();
       if (this.options.renderShadows) {
-        var shadowRay = new Ray(info.position, v);
+        var shadowRay = Ray(info.position, v);
         shadowInfo = this.testIntersection(shadowRay, scene, info.shape);
         if (shadowInfo.isHit && shadowInfo.shape != info.shape
             /*&& shadowInfo.shape.type != 'PLANE'*/) {


### PR DESCRIPTION
Not sure if this PR fits the benchmark philosophy or not (how far can we push handmade JavaScript optimizations? is that fair?), anyway turning these two classes into plain objects seems to increase the speed by ~15% in cold run tests. 

Just trying to help the performance of `Tracer.js` as it's the only benchmark where JS is behind `dart2js`. 
